### PR TITLE
Omit GL_FRAMEBUFFER_SRGB glEnable/Disable given IMGUI_APP_GLFW_GL3 on non-ES2/3 systems

### DIFF
--- a/shared/imgui_app.cpp
+++ b/shared/imgui_app.cpp
@@ -1048,7 +1048,7 @@ static bool ImGuiApp_ImplGlfwGL3_NewFrame(ImGuiApp* app_opaque)
     if (glfwWindowShouldClose(app->window))
         return false;
     app->DpiScale = ImGuiApp_ImplGlfw_GetDPI(app->window);
-#if !defined (IMGUI_IMPL_OPENGL_ES3) && !defined(IMGUI_IMPL_OPENGL_ES2)
+#if !defined(IMGUI_IMPL_OPENGL_ES3) && !defined(IMGUI_IMPL_OPENGL_ES2)
     if (app->SrgbFramebuffer)
         glEnable(GL_FRAMEBUFFER_SRGB);
     else


### PR DESCRIPTION
GLES doesn't use `GL_FRAMEBUFFER_SRGB` (apparently it's auto-converted). Screencapture works with this condition implemented given `IMGUI_APP_GLFW_GL3` & `IMGUI_IMPL_OPENGL_ES3`. I am yet to run videocapture.


[imgui_impl_opengl3_loader.h:344-351](https://github.com/ocornut/imgui/blob/master/backends/imgui_impl_opengl3_loader.h), definition for non-GL3. 
```
#endif /* GL_VERSION_2_0 */
#ifndef GL_VERSION_3_0
typedef khronos_uint16_t GLhalf;
#define GL_MAJOR_VERSION                  0x821B
#define GL_MINOR_VERSION                  0x821C
#define GL_NUM_EXTENSIONS                 0x821D
#define GL_FRAMEBUFFER_SRGB               0x8DB9
#define GL_VERTEX_ARRAY_BINDING           0x85B5
```
[gl3.h in GLES3](https://github.com/KhronosGroup/OpenGL-Registry/blob/main/api/GLES3/gl3.h) doesn't include GL_FRAMEBUFFER_SRGB either.