### PR TITLE
Update imgui_te_context.cpp

### DIFF
--- a/imgui_test_engine/imgui_te_context.cpp
+++ b/imgui_test_engine/imgui_te_context.cpp
@@ -865,14 +865,15 @@ static void ItemInfoErrorLog(ImGuiTestContext* ctx, ImGuiTestRef ref, ImGuiID fu
 
     // Prefixing the string with / ignore the reference/current ID
     Str256 msg;
-    if (ref.Path && ref.Path[0] == '/' && ctx->RefStr[0] != 0)
-        msg.setf("Unable to locate item: '%s'", ref.Path);
-    else if (ref.Path && full_id != 0)
-        msg.setf("Unable to locate item: '%s/%s' (0x%08X)", ctx->RefStr, ref.Path, full_id);
-    else if (ref.Path)
-        msg.setf("Unable to locate item: '%s/%s'", ctx->RefStr, ref.Path);
-    else
+    if (!ref.Path)
         msg.setf("Unable to locate item: 0x%08X", ref.ID);
+    else if (ref.Path[0] == '/' && ctx->RefStr[0] != 0)
+        msg.setf("Unable to locate item: '%s'", ref.Path);
+    else if (full_id)
+        msg.setf("Unable to locate item: '%s/%s' (0x%08X)", ctx->RefStr, ref.Path, full_id);
+    else
+        msg.setf("Unable to locate item: '%s/%s'", ctx->RefStr, ref.Path);
+        
 
     //if (flags & ImGuiTestOpFlags_NoError)
     //    ctx->LogInfo("Ignored: %s", msg.c_str()); // FIXME


### PR DESCRIPTION
Minor code simplification, extract the check on `ref.Path` nullability at the begin, in all the remaining predicates, `ref.Path` can be assumed different from null