### PR TITLE
TestSuite: added "nav_ctrl_tab_customization"

### DIFF
--- a/imgui_test_engine/imgui_te_engine.cpp
+++ b/imgui_test_engine/imgui_te_engine.cpp
@@ -1340,6 +1340,9 @@ static void ImGuiTestEngine_RunTest(ImGuiTestEngine* engine, ImGuiTestContext* c
     ImGuiIO backup_io = ctx->UiContext->IO;
     ImGuiStyle backup_style = ctx->UiContext->Style;
     ImGuiDebugLogFlags backup_debug_log_flags = ctx->UiContext->DebugLogFlags;
+    ImGuiKeyChord backup_nav_windowing_key_next = ctx->UiContext->ConfigNavWindowingKeyNext;
+    ImGuiKeyChord backup_nav_windowing_key_prev = ctx->UiContext->ConfigNavWindowingKeyPrev;
+
     memset(backup_io.MouseDown, 0, sizeof(backup_io.MouseDown));
     for (int n = 0; n < IM_ARRAYSIZE(backup_io.KeysData); n++)
         backup_io.KeysData[n].Down = false;
@@ -1505,6 +1508,8 @@ static void ImGuiTestEngine_RunTest(ImGuiTestEngine* engine, ImGuiTestContext* c
     ctx->UiContext->IO = backup_io;
     ctx->UiContext->Style = backup_style;
     ctx->UiContext->DebugLogFlags = backup_debug_log_flags;
+    ctx->UiContext->ConfigNavWindowingKeyNext = backup_nav_windowing_key_next;
+    ctx->UiContext->ConfigNavWindowingKeyPrev = backup_nav_windowing_key_prev;
 }
 
 //-------------------------------------------------------------------------


### PR DESCRIPTION
Functional test for https://github.com/ocornut/imgui/issues/4828

This adds two tests:

* `nav_ctrl_tab_customization` - For ensuring `ConfigNavWindowingKeyNext`/`ConfigNavWindowingKeyPrev` can be configured.
* `nav_ctrl_tab_disabled` - For ensuring setting them to 0 disables the keys.

I also added a test for Ctrl+Shift+Tab to `nav_ctrl_tab_focusing` as this key combo does not appear to be tested elsewhere.

--------------

While implementing these tests I noticed that the assert you get with this configuration is a bit confusing:

```
g->ConfigNavWindowingKeyNext = ImGuiKey_N;
g->ConfigNavWindowingKeyPrev = 0;
```

My expectation was that I'd get a `next` key with no modifier along with no `prev` key at all. Instead you get an assert about the two not having modifiers in common.

Not sure if this is a scenario you want to support, but I thought I'd mention it.