### PR TITLE
Add '-list-tests' cmdline option

### DIFF
--- a/imgui_test_suite/imgui_test_suite.cpp
+++ b/imgui_test_suite/imgui_test_suite.cpp
@@ -50,6 +50,7 @@
 #include "imgui_test_engine/imgui_te_utils.h"
 #include "imgui_test_engine/imgui_te_ui.h"
 #include "imgui_test_engine/imgui_capture_tool.h"
+#include "imgui_test_engine/imgui_te_internal.h"
 #include "imgui_test_engine/thirdparty/Str/Str.h"
 
 // imgui_app (this is a helper to wrap multiple backends)
@@ -111,6 +112,7 @@ struct TestSuiteApp
     Str128                      OptExportFilename;
     ImGuiTestEngineExportFormat OptExportFormat = ImGuiTestEngineExportFormat_JUnitXml;
     ImVector<char*>             TestsToRun;
+    bool                        OptListTests = false;
 };
 
 static void TestSuite_ShowUI(TestSuiteApp* app)
@@ -180,6 +182,7 @@ static void TestSuite_PrintCommandLineHelp()
     printf("   [pattern]               : queue all tests containing the word [pattern].\n");
     printf("   [-pattern]              : queue all tests not containing the word [pattern].\n");
     printf("   [^pattern]              : queue all tests starting with the word [pattern].\n");
+    printf("   -list-tests             : list all tests, one per line\n");
 }
 
 static bool TestSuite_ParseCommandLineOptions(TestSuiteApp* app, int argc, char** argv)
@@ -248,6 +251,11 @@ static bool TestSuite_ParseCommandLineOptions(TestSuiteApp* app, int argc, char*
         else if (strcmp(argv[n], "-export-file") == 0 && n + 1 < argc)
         {
             app->OptExportFilename = argv[n + 1];
+        }
+        else if (strcmp(argv[n], "-list-tests") == 0)
+        {
+            app->OptListTests = true;
+            app->OptGui = false;
         }
         else
         {
@@ -538,6 +546,18 @@ int main(int argc, char** argv)
         fprintf(stderr, "Dear ImGui git repository was not found.\n");
     }
     printf("Git branch: \"%s\"\n", test_io.GitBranchName);
+
+    // List all tests and exit the program
+    if (app->OptListTests)
+    {
+        for (int n = 0; n < engine->TestsAll.Size; n++)
+        {
+            ImGuiTest* test = engine->TestsAll[n];
+            printf("Test: '%s' '%s'\n", test->Category, test->Name);
+        }
+
+        return 0;
+    }
 
     // Start engine
     ImGuiTestEngine_Start(engine, ImGui::GetCurrentContext());


### PR DESCRIPTION
- I added new command line option `-list-tests`. 
- It prints all tests from `app->TestsAll` in the following format:

> Test: '_category_' '_name_'

- In command line you must run `imgui_test_suite.exe -list-tests` and the output looks the following way:

![image](https://github.com/ocornut/imgui_test_engine/assets/30224608/9e50ba9b-c98c-46f0-8953-3c5fd06db127)

**What you might not like**:
- I included `imgui_te_internal.h` header, which presumably should not be included anywhere (because it is _internal_)
- I added early return on line 559, which is sometimes considered as antipattern

**Why I opened this PR?** 
- Idk, to be honest, it is not an important change.
- It allows developers to print all test cases in command line, so if they just want to look at what tests were written for `test_imgui_suite` app, they won't have to run the whole app UI and ImGUI Test Engine UI.
- Also, it is kind of an example for developers on how they can print ImGUI Test Engine tests in their own applications.
- Finally, outputs in command line can be piped, e.g. you could save a list of tests to txt file by executing `imgui_test_engine.exe -list-tests > text.txt`