### PR TITLE
imgui_te_utils: support emscripten / fix ImFileCreateDirectoryChain

### DIFF
--- a/imgui_test_engine/imgui_te_utils.cpp
+++ b/imgui_test_engine/imgui_te_utils.cpp
@@ -280,7 +280,7 @@ bool ImFileCreateDirectoryChain(const char* path, const char* path_end)
     path_local[path_len] = 0;
 
 #if defined(_WIN32)
-    ImVector<ImWchar> buf;
+    ImVector<wchar_t> buf;
 #endif
     // Modification of passed file_name allows us to avoid extra temporary memory allocation.
     // strtok() pokes \0 into places where slashes are, we create a directory using directory_name and restore slash.
@@ -291,10 +291,12 @@ bool ImFileCreateDirectoryChain(const char* path, const char* path_end)
             *(token - 1) = IM_DIR_SEPARATOR;
 
 #if defined(_WIN32)
-        // Use ::CreateDirectoryW() because ::CreateDirectoryA() treat filenames in the local code-page instead of UTF-8.
-        const int filename_wsize = ImTextCountCharsFromUtf8(path_local, NULL) + 1;
+        // Use ::CreateDirectoryW() because ::CreateDirectoryA() treat filenames in the local code-page instead of UTF-8
+        // We cannot use ImWchar, which can be 32bits if IMGUI_USE_WCHAR32 (and CreateDirectoryW require 16bits wchar)
+        int filename_wsize = MultiByteToWideChar(CP_UTF8, 0, path_local, -1, NULL, 0);
         buf.resize(filename_wsize);
-        ImTextStrFromUtf8(&buf[0], filename_wsize, path_local, NULL);
+        MultiByteToWideChar(CP_UTF8, 0, path_local, -1, &buf[0], filename_wsize);
+
         if (!::CreateDirectoryW((wchar_t*)&buf[0], NULL) && GetLastError() != ERROR_ALREADY_EXISTS)
 #else
         if (mkdir(path_local, S_IRWXU) != 0 && errno != EEXIST)

--- a/imgui_test_engine/imgui_te_utils.cpp
+++ b/imgui_test_engine/imgui_te_utils.cpp
@@ -785,7 +785,7 @@ const ImBuildInfo* ImBuildGetCompilationInfo()
         // CPU
 #if defined(_M_X86) || defined(_M_IX86) || defined(__i386) || defined(__i386__) || defined(_X86_) || defined(_M_AMD64) || defined(_AMD64_) || defined(__x86_64__)
         build_info.Cpu = (sizeof(size_t) == 4) ? "X86" : "X64";
-#elif defined(__aarch64__)
+#elif defined(__aarch64__) || (defined(_M_ARM64) && defined(_WIN64))
         build_info.Cpu = "ARM64";
 #elif defined(__EMSCRIPTEN__)
         build_info.Cpu = "WebAsm";

--- a/imgui_test_engine/imgui_te_utils.cpp
+++ b/imgui_test_engine/imgui_te_utils.cpp
@@ -787,6 +787,8 @@ const ImBuildInfo* ImBuildGetCompilationInfo()
         build_info.Cpu = (sizeof(size_t) == 4) ? "X86" : "X64";
 #elif defined(__aarch64__)
         build_info.Cpu = "ARM64";
+#elif defined(__EMSCRIPTEN__)
+        build_info.Cpu = "WebAsm";
 #else
 #error
         build_info.Cpu = (sizeof(size_t) == 4) ? "Unknown32" : "Unknown64";


### PR DESCRIPTION
Hello Omar,

This PR contains small fixes:

- support build on emscripten and windows arm 64
- fix an issue inside ImFileCreateDirectoryChain which fails on windows if IMGUI_USE_WCHAR32 is defined
  (in which case `ImTextStrFromUtf8` will produce a 32 bits text, which cannot be used by CreateDirectoryW)

