### PR TITLE
imgui_app: Win32 DX11: Fix non UNICODE builds

### DIFF
--- a/shared/imgui_app.cpp
+++ b/shared/imgui_app.cpp
@@ -286,7 +286,6 @@ static bool ImGuiApp_ImplWin32DX11_InitCreateWindow(ImGuiApp* app_opaque, const 
 
     // Create application window
     app->WC = { sizeof(WNDCLASSEX), CS_CLASSDC, ImGuiApp_ImplWin32_WndProc, 0L, 0L, ::GetModuleHandle(NULL), NULL, NULL, NULL, NULL, TEXT("ImGuiApp"), NULL };
-
     ::RegisterClassEx(&app->WC);
 
     POINT pos = { 1, 1 };

--- a/shared/imgui_app.cpp
+++ b/shared/imgui_app.cpp
@@ -285,7 +285,8 @@ static bool ImGuiApp_ImplWin32DX11_InitCreateWindow(ImGuiApp* app_opaque, const 
         ImGui_ImplWin32_EnableDpiAwareness();
 
     // Create application window
-    app->WC = { sizeof(WNDCLASSEXA), CS_CLASSDC, ImGuiApp_ImplWin32_WndProc, 0L, 0L, ::GetModuleHandle(NULL), NULL, NULL, NULL, NULL, L"ImGuiApp", NULL };
+    app->WC = { sizeof(WNDCLASSEX), CS_CLASSDC, ImGuiApp_ImplWin32_WndProc, 0L, 0L, ::GetModuleHandle(NULL), NULL, NULL, NULL, NULL, TEXT("ImGuiApp"), NULL };
+
     ::RegisterClassEx(&app->WC);
 
     POINT pos = { 1, 1 };
@@ -314,8 +315,8 @@ static bool ImGuiApp_ImplWin32DX11_InitCreateWindow(ImGuiApp* app_opaque, const 
     app->Hwnd = ::CreateWindowEx(0L, app->WC.lpszClassName, window_title_t, WS_OVERLAPPEDWINDOW, pos.x, pos.y, (int)window_size.x, (int)window_size.y, NULL, NULL, app->WC.hInstance, NULL);
     free(window_title_t);
 #else
-    const char* window_title_t = window_titLe_a;
-    app->Hwnd = ::CreateWindowEx(0L, app->WC.lpszClassName, window_titLe_t, WS_OVERLAPPEDWINDOW, pos.x, pos.y, (int)window_size.x, (int)window_size.y, NULL, NULL, app->WC.hInstance, NULL);
+    const char* window_title_t = window_title_a;
+    app->Hwnd = ::CreateWindowEx(0L, app->WC.lpszClassName, window_title_t, WS_OVERLAPPEDWINDOW, pos.x, pos.y, (int)window_size.x, (int)window_size.y, NULL, NULL, app->WC.hInstance, NULL);
 #endif
 
     // Initialize Direct3D


### PR DESCRIPTION
Fixes build failures from `imgui_app.cpp` when `UNICODE` is not defined.
- Fixes `WNDCLASSEX` initializer ambiguity due to WCHAR literal in initializer
- Fixes `window_titLe_a` typo in non unicode CreateWindow block.