### PR TITLE
ImGuiTestEngine_FindItemDebugLabel: if TestEngine==NULL, return NULL

### DIFF
--- a/imgui_test_engine/imgui_te_engine.cpp
+++ b/imgui_test_engine/imgui_te_engine.cpp
@@ -2054,8 +2054,7 @@ ImGuiTextBuffer* ImGuiTestEngine_GetTempStringBuilder()
 
 const char* ImGuiTestEngine_FindItemDebugLabel(ImGuiContext* ui_ctx, ImGuiID id)
 {
-    IM_ASSERT(ui_ctx->TestEngine != NULL);
-    if (id == 0)
+    if (ui_ctx->TestEngine == NULL || id == 0)
         return NULL;
     if (ImGuiTestItemInfo* id_info = ImGuiTestEngine_FindItemInfo((ImGuiTestEngine*)ui_ctx->TestEngine, id, ""))
         return id_info->DebugLabel;


### PR DESCRIPTION
See https://github.com/ocornut/imgui/pull/7228

ImGuiTestEngine_FindItemDebugLabel should gracefully handle cases where the test engine was not started.