### PR TITLE
Test and fix for multiple sub menus

### DIFF
--- a/imgui_test_engine/imgui_te_context.cpp
+++ b/imgui_test_engine/imgui_te_context.cpp
@@ -3212,7 +3212,7 @@ void    ImGuiTestContext::MenuAction(ImGuiTestAction action, ImGuiTestRef ref)
                 IM_CHECK_SILENT(item != NULL);
                 item->RefCount++;
                 MouseSetViewport(item->Window);
-                if (depth > 1 && (Inputs->MousePosValue.x <= item->RectFull.Min.x || Inputs->MousePosValue.x >= item->RectFull.Max.x))
+                if (depth > 0 && (Inputs->MousePosValue.x <= item->RectFull.Min.x || Inputs->MousePosValue.x >= item->RectFull.Max.x))
                     MouseMoveToPos(ImVec2(item->RectFull.GetCenter().x, Inputs->MousePosValue.y));
                 if (depth > 0 && (Inputs->MousePosValue.y <= item->RectFull.Min.y || Inputs->MousePosValue.y >= item->RectFull.Max.y))
                     MouseMoveToPos(ImVec2(Inputs->MousePosValue.x, item->RectFull.GetCenter().y));

--- a/imgui_test_suite/imgui_tests_core.cpp
+++ b/imgui_test_suite/imgui_tests_core.cpp
@@ -892,6 +892,59 @@ void RegisterTests_Window(ImGuiTestEngine* e)
         }
     };
 
+    // ## Test menus in a popup window that are very horizontal/diagonal
+    t = IM_REGISTER_TEST(e, "window", "window_popup_with_sub_menus");
+    t->GuiFunc = [](ImGuiTestContext* ctx)
+    {
+        ImGui::Begin("Test Window", NULL, ImGuiWindowFlags_NoSavedSettings);
+        if (ImGui::Button("Open Menu Popup"))
+            ImGui::OpenPopup("Menu Popup");
+
+        if (ImGui::BeginPopup("Menu Popup"))
+        {
+            if (ImGui::BeginMenu("Sub Menu"))
+            {
+                ImGui::MenuItem("Lorem");
+                ImGui::MenuItem("Ipsum");
+                if (ImGui::BeginMenu("Second Sub Menu 1"))
+                {
+                    ImGui::MenuItem("Sub Item 1");
+                    ImGui::EndMenu();
+                }
+                if (ImGui::BeginMenu("Second Sub Menu 2"))
+                {
+                    ImGui::MenuItem("Sub Item 2");
+                    if (ImGui::BeginMenu("Third Sub Menu 1"))
+                    {
+                        ImGui::MenuItem("Item 3");
+                        ImGui::EndMenu();
+                    }
+                    if (ImGui::BeginMenu("Third Sub Menu 2"))
+                    {
+                        ImGui::MenuItem("Sub Item 4");
+                        ImGui::MenuItem("Sub Item 5");
+                        ImGui::MenuItem("Sub Item 6");
+                        ImGui::EndMenu();
+                    }
+                    ImGui::EndMenu();
+                }
+                ImGui::EndMenu();
+            }
+            ImGui::MenuItem("consectetur adipiscing elit");
+            ImGui::MenuItem("sed do eiusmod tempor incididunt");
+            ImGui::EndPopup();
+        }
+
+        ImGui::End();
+    };
+    t->TestFunc = [](ImGuiTestContext* ctx)
+    {
+        ctx->SetRef("Test Window");
+        ctx->ItemClick("Open Menu Popup");
+        ctx->SetRef("//$FOCUSED");
+        ctx->MenuClick("Sub Menu/Second Sub Menu 2/Third Sub Menu 2/Sub Item 6");
+    };
+
     // ## Test hovering across levels of menu
     t = IM_REGISTER_TEST(e, "window", "window_popup_menu_hover");
     t->GuiFunc = [](ImGuiTestContext* ctx)


### PR DESCRIPTION
I was finding that some of my tests were failing when trying to access multiple sub menus. I think what was happening is that the mouse pointer is moved down first then relying on the ItemAction command to move the mouse over to the right before the sub menu closes because the mouse is no longer hovered. 

I created a new test in the test suite but it only fails if you run in normal speed. In my app it fails in fast mode too because it runs slower then the test suite tests so the menu gets more of a chance to register that it's no longer hovered.

I have a "fix", not sure it it's the best option but it works and all tests pass. It just allows for the mouse pointer to move to the right over the sub menu first before moving down into position.