### PR TITLE
TestEngine: Add clickable debug output for msvc

### DIFF
--- a/imgui_test_engine/imgui_te_ui.cpp
+++ b/imgui_test_engine/imgui_te_ui.cpp
@@ -487,6 +487,16 @@ static void ShowTestGroup(ImGuiTestEngine* e, ImGuiTestGroup group, Str* filter)
                     e->IO.SrcFileOpenFunc(test->SourceFile, test->SourceLine, e->IO.SrcFileOpenUserData);
                 if (ImGui::MenuItem("View source...", NULL, false, test->SourceFile != NULL))
                     view_source = true;
+#ifdef _MSC_VER
+                if (ImGui::GetIO().ConfigDebugIsDebuggerPresent)
+                {
+                    if (ImGui::MenuItem("Debug output source...", NULL, false, test->SourceFile != NULL))
+                    {
+                        Str256f dbgbuf("%s(%d): Doubleclick me\n", test->SourceFile, test->SourceLine);
+                        ImOsOutputDebugString(dbgbuf.c_str());
+                    }
+                }
+#endif
 
                 if (group == ImGuiTestGroup_Perfs && ImGui::MenuItem("View perflog"))
                 {


### PR DESCRIPTION
Doubleclicking the debug output will open the file/line in the ide:

The format `file(line):` is recognized by MSVC in the output window (among others), doubleclicking it will open the file at that line:

![image](https://github.com/user-attachments/assets/23840b8a-1ee9-4924-8a16-4f4f37e2c62d)
