### PR TITLE
InputText word/line selection mode tests

### DIFF
--- a/imgui_test_engine/imgui_te_context.cpp
+++ b/imgui_test_engine/imgui_te_context.cpp
@@ -2153,7 +2153,7 @@ void    ImGuiTestContext::MouseClick(ImGuiMouseButton button)
 }
 
 // TODO: click time argument (seconds and/or frames)
-void    ImGuiTestContext::MouseClickMulti(ImGuiMouseButton button, int count)
+void    ImGuiTestContext::MouseClickMulti(ImGuiMouseButton button, int count, bool hold)
 {
     if (IsError())
         return;
@@ -2181,7 +2181,9 @@ void    ImGuiTestContext::MouseClickMulti(ImGuiMouseButton button, int count)
             Yield(2); // Leave enough time for non-alive IDs to expire. (#5325)
         else
             Yield();
-        Inputs->MouseButtonsValue = 0;
+
+        if (n != count - 1 || !hold)
+            Inputs->MouseButtonsValue = 0;
 
         if (EngineIO->ConfigRunSpeed != ImGuiTestRunSpeed_Fast)
             Yield(2); // Not strictly necessary but covers more variant.

--- a/imgui_test_engine/imgui_te_context.h
+++ b/imgui_test_engine/imgui_te_context.h
@@ -347,7 +347,7 @@ struct IMGUI_API ImGuiTestContext
     void        MouseMoveToPos(ImVec2 pos);
     void        MouseTeleportToPos(ImVec2 pos, ImGuiTestOpFlags flags = ImGuiTestOpFlags_None);
     void        MouseClick(ImGuiMouseButton button = 0);
-    void        MouseClickMulti(ImGuiMouseButton button, int count);
+    void        MouseClickMulti(ImGuiMouseButton button, int count, bool hold = false);
     void        MouseDoubleClick(ImGuiMouseButton button = 0);
     void        MouseDown(ImGuiMouseButton button = 0);
     void        MouseUp(ImGuiMouseButton button = 0);


### PR DESCRIPTION
First draft of tests as requested in https://github.com/ocornut/imgui/pull/8032.

`CalcTextSize()` gives bouding rects. So, had to hack together `index_pos()` to get coords for individual chars in multiline text.

https://github.com/user-attachments/assets/fac5e7ea-c2b8-4f56-aee1-b8c46182d558

