### PR TITLE
Add a name to the `ItemOpenFullPath()` argument

### DIFF
--- a/imgui_test_engine/imgui_te_context.h
+++ b/imgui_test_engine/imgui_te_context.h
@@ -426,7 +426,7 @@ struct IMGUI_API ImGuiTestContext
     void        ItemClose(ImGuiTestRef ref, ImGuiTestOpFlags flags = 0)                 { ItemAction(ImGuiTestAction_Close, ref, flags); }
     void        ItemInput(ImGuiTestRef ref, ImGuiTestOpFlags flags = 0)                 { ItemAction(ImGuiTestAction_Input, ref, flags); }
     void        ItemNavActivate(ImGuiTestRef ref, ImGuiTestOpFlags flags = 0)           { ItemAction(ImGuiTestAction_NavActivate, ref, flags); }
-    bool        ItemOpenFullPath(ImGuiTestRef);
+    bool        ItemOpenFullPath(ImGuiTestRef ref);
 
     // Item/Widgets: Batch actions over an entire scope
     void        ItemActionAll(ImGuiTestAction action, ImGuiTestRef ref_parent, const ImGuiTestActionFilter* filter = nullptr);


### PR DESCRIPTION
Very small change, but it removes an edge case when generating C bindings.