### PR TITLE
Delete `ItemOpenFullPath()`

### DIFF
--- a/imgui_test_engine/imgui_te_context.h
+++ b/imgui_test_engine/imgui_te_context.h
@@ -426,7 +426,6 @@ struct IMGUI_API ImGuiTestContext
     void        ItemClose(ImGuiTestRef ref, ImGuiTestOpFlags flags = 0)                 { ItemAction(ImGuiTestAction_Close, ref, flags); }
     void        ItemInput(ImGuiTestRef ref, ImGuiTestOpFlags flags = 0)                 { ItemAction(ImGuiTestAction_Input, ref, flags); }
     void        ItemNavActivate(ImGuiTestRef ref, ImGuiTestOpFlags flags = 0)           { ItemAction(ImGuiTestAction_NavActivate, ref, flags); }
-    bool        ItemOpenFullPath(ImGuiTestRef ref);
 
     // Item/Widgets: Batch actions over an entire scope
     void        ItemActionAll(ImGuiTestAction action, ImGuiTestRef ref_parent, const ImGuiTestActionFilter* filter = nullptr);


### PR DESCRIPTION
I ran into a linking error with this function, and when I checked it turns out that there's actually no implementation at all :sweat_smile: According to git the signature was created way back in 4054b54c871a2427f1e3ffc00d505d3e27fd0d5d when `ItemInfoOpenFullPath()` was added. Maybe `ItemOpenFullPath()` was an old change added by mistake?