### PR TITLE
TestSuite: added "imgui_test_suite_imconfig.h" hader to get IMGUI_BROKEN_TESTS

### DIFF
--- a/imgui_test_suite/imgui_tests_inputs.cpp
+++ b/imgui_test_suite/imgui_tests_inputs.cpp
@@ -6,6 +6,7 @@
 #define IMGUI_DEFINE_MATH_OPERATORS
 #include "imgui.h"
 #include "imgui_internal.h"
+#include "imgui_test_suite_imconfig.h"
 #include "imgui_test_suite.h"
 #include "imgui_test_engine/imgui_te_engine.h"      // IM_REGISTER_TEST()
 #include "imgui_test_engine/imgui_te_context.h"


### PR DESCRIPTION
No other included files has this definition and its usage fails compilation.