### PR TITLE
CrashHandler: SA_RESETHAND to avoid abort() reentry spam (on *nixes)

### DIFF
--- a/imgui_test_engine/imgui_te_engine.cpp
+++ b/imgui_test_engine/imgui_te_engine.cpp
@@ -2123,7 +2123,7 @@ void ImGuiTestEngine_InstallDefaultCrashHandler()
     // Install a crash handler to relevant signals.
     struct sigaction action = {};
     action.sa_handler = ImGuiTestEngine_CrashHandlerUnix;
-    action.sa_flags = SA_SIGINFO;
+    action.sa_flags = SA_RESETHAND; // one-shot
     sigaction(SIGILL, &action, nullptr);
     sigaction(SIGABRT, &action, nullptr);
     sigaction(SIGFPE, &action, nullptr);


### PR DESCRIPTION
`ImGuiTestEngine_CrashHandlerUnix()` calls abort() after invoking the crash handler. 

However abort() unmasks SIGABRT and re-raises it, which on macOS (and other POSIX systems) reenters the handler.

When there was a crash, the message `**ImGuiTestEngine_CrashHandler()** Crashed while running ...` could then be printed about 20 times before the process finally dies.

Added a flag `SA_RESETHAND` which is actually the way to get a one-shot behavior. 

Note: `sa_flags = SA_SIGINFO` had no effect here since we use sa_handler, not sa_sigaction. 



Minimal repro code (this use Hello ImGui, but the gist is actually in RegisterTests())

```cpp
#include "hello_imgui/hello_imgui.h"
#include "imgui.h"
#include "imgui_test_engine/imgui_te_engine.h"
#include "imgui_test_engine/imgui_te_context.h"

#include <cstdlib>

static ImGuiTest* gCrashingTest = nullptr;

static void RegisterTests()
{
    ImGuiTestEngine* engine = HelloImGui::GetImGuiTestEngine();
    gCrashingTest = IM_REGISTER_TEST(engine, "Repro", "Crash via abort()");
    gCrashingTest->TestFunc = [](ImGuiTestContext*) {
        // Stand-in for any uncaught native crash inside a test function
        // (e.g. an unhandled C++ exception that reaches std::terminate,
        // which in turn calls abort()).
        std::abort();
    };
}

static void Gui()
{
    ImGui::TextWrapped("Click the button to queue a test that calls abort().");
    ImGui::TextWrapped("Watch the terminal: the crash-handler banner will print many times before the process dies.");
    ImGui::Separator();
    if (ImGui::Button("Run crashing test"))
    {
        ImGuiTestEngine* engine = HelloImGui::GetImGuiTestEngine();
        ImGuiTestEngine_QueueTest(engine, gCrashingTest);
    }
}

int main()
{
    HelloImGui::RunnerParams params;
    params.appWindowParams.windowTitle = "CrashHandler reentry repro";
    params.useImGuiTestEngine = true;
    params.callbacks.RegisterTests = RegisterTests;
    params.callbacks.PostInit = []() {
        // hello_imgui does not install the default crash handler automatically.
        ImGuiTestEngine_InstallDefaultCrashHandler();
    };
    params.callbacks.ShowGui = Gui;
    HelloImGui::Run(params);
}
```

This used to print (on macOS):

```
**ImGuiTestEngine_CrashHandler()** Crashed while running "Crash via abort()" :(
**ImGuiTestEngine_CrashHandler()** Crashed while running "Crash via abort()" :(
**ImGuiTestEngine_CrashHandler()** Crashed while running "Crash via abort()" :(
... (about 50 times)

Failing tests:
- Crash via abort()

Tests Result: Errors
(0/1 tests passed)
```

And with the fix, we have

```

Failing tests:
- Crash via abort()

Tests Result: Errors
(0/1 tests passed)
**ImGuiTestEngine_CrashHandler()** Crashed while running "Crash via abort()" :(

```
