### PR TITLE
ImOsOpenInShell: skip system() on iOS/tvOS/watchOS/visionOS

### DIFF
--- a/imgui_test_engine/imgui_te_utils.cpp
+++ b/imgui_test_engine/imgui_te_utils.cpp
@@ -36,6 +36,9 @@
 #if defined(__linux) || defined(__linux__) || defined(__MACH__) || defined(__MSL__) || defined(__MINGW32__)
 #include <pthread.h>    // pthread_setname_np()
 #endif
+#if defined(__APPLE__)
+#include <TargetConditionals.h>   // TARGET_OS_IPHONE
+#endif
 #include <chrono>       // high_resolution_clock::now()
 #include <thread>       // this_thread::sleep_for()
 
@@ -999,6 +1002,11 @@ void    ImOsOpenInShell(const char* path)
 #if defined(_WIN32) && !IMGUI_TEST_ENGINE_IS_GAME_CONSOLE
     ImPathFixSeparatorsForCurrentOS(command.c_str());
     ::ShellExecuteA(nullptr, "open", command.c_str(), nullptr, nullptr, SW_SHOWDEFAULT);
+#elif defined(__APPLE__) && TARGET_OS_IPHONE
+    // iOS / tvOS / watchOS / visionOS deprecate system() and App Store review
+    // rejects binaries that call it. No shell-out is available; treat
+    // ImOsOpenInShell as a no-op on those platforms.
+    IM_UNUSED(path);
 #elif !IMGUI_TEST_ENGINE_IS_GAME_CONSOLE
 #if __APPLE__
     const char* open_executable = "open";


### PR DESCRIPTION
## Motivation

`ImOsOpenInShell()` shells out via `system("open …")` (or `xdg-open` on Linux,
`ShellExecuteA` on Windows). Apple deprecated `system()` on iOS-family
platforms (iOS, tvOS, watchOS, visionOS) and App Store review rejects
binaries that reference it. Apps targeting those platforms that include
imgui_test_engine sources currently won't pass review.

## Change

Gate the `system()` branch on `!(defined(__APPLE__) && TARGET_OS_IPHONE)`.
On iOS-family the function becomes a no-op — there's no equivalent shell-out
mechanism available there, and the rest of the test engine still works fine.
macOS / Linux / Windows paths are unchanged.

Adds `#include <TargetConditionals.h>` (guarded on `__APPLE__`) so
`TARGET_OS_IPHONE` resolves.

## Notes

- `TARGET_OS_IPHONE` is `1` on iOS, tvOS, watchOS, and visionOS, and `0` on
  macOS — matches the set of platforms where `system()` is rejected.
- Considered making it an `IM_ASSERT(0)` instead of a silent no-op, but
  the rest of the engine handles `ImOsOpenInShell` being called from
  debug-UI helpers like "open log dir" buttons. Asserting at runtime would
  break those flows; a no-op leaves them harmlessly degraded.
- Tested on iOS/Darwin builds via a downstream Conan recipe that used to
  carry an unconditional `system(command.c_str());` → `""` patch.
  This change lets that recipe drop its patch entirely.