### PR TITLE
TestEngine: wildcard ("**/") item search handles "\\/" escaped slashes in labels

### DIFF
--- a/imgui_test_engine/imgui_te_context.cpp
+++ b/imgui_test_engine/imgui_te_context.cpp
@@ -900,18 +900,46 @@ ImGuiID ImGuiTestContext::ItemInfoHandleWildcardSearch(const char* wildcard_pref
         task->InPrefixId = RefID;
     task->OutItemId = 0;
 
-    // Advance pointer to point it to the last label
+    // Advance pointer to point it to the last label (after the last '/') and fill its depth (InSuffixDepth)
+    // Labels are separated by '/', except if this char is escaped by a `\\` (where inhibit_one will be true)
     task->InSuffix = task->InSuffixLastItem = wildcard_suffix_start;
-    for (const char* c = task->InSuffix; *c; c++)
-        if (*c == '/')
-            task->InSuffixLastItem = c + 1;
-    task->InSuffixLastItemHash = ImHashStr(task->InSuffixLastItem, 0, 0);
-
-    // Count number of labels
     task->InSuffixDepth = 1;
-    for (const char* c = wildcard_suffix_start; *c; c++)
-        if (*c == '/')
+    bool inhibit_one = false;
+    for (const char* c = task->InSuffix; *c; c++)
+    {
+        if (*c == '\\' && !inhibit_one)
+        {
+            inhibit_one = true;
+            continue;
+        }
+        if (*c == '/' && !inhibit_one)
+        {
+            task->InSuffixLastItem = c + 1;
             task->InSuffixDepth++;
+        }
+        inhibit_one = false;
+    }
+
+    // Escape char (`\\`) shall not take part in the hash computation of a label (Hash("Some\\/Label") = Hash("Some/Label")).
+    if (strchr(task->InSuffixLastItem, '\\') == nullptr)
+    {
+        task->InSuffixLastItemHash = ImHashStr(task->InSuffixLastItem, 0, 0);
+    }
+    else
+    {
+        Str256 last_item_unescaped;
+        for (const char* c = task->InSuffixLastItem; *c; c++)
+        {
+            if (*c == '\\')
+            {
+                c++;
+                if (*c == 0)
+                    break;
+            }
+            last_item_unescaped.append(*c);
+        }
+        task->InSuffixLastItemHash = ImHashStr(last_item_unescaped.c_str(), 0, 0);
+    }
 
     int retries = 0;
     while (retries < 2 && task->OutItemId == 0)

--- a/imgui_test_suite/imgui_tests_core.cpp
+++ b/imgui_test_suite/imgui_tests_core.cpp
@@ -6742,6 +6742,11 @@ void RegisterTests_TestEngine(ImGuiTestEngine* e)
         ImGui::Checkbox("Test1b", &vars.Bool1);
         ImGui::PopID();
 
+        ImGui::Checkbox("Hello/World", &vars.BoolArray[0]); // Label containing a slash
+        ImGui::PushID("node2/sub");                         // Pushed ID string containing a slash
+        ImGui::Checkbox("Test1c", &vars.BoolArray[1]);
+        ImGui::PopID();
+
         ImGui::BeginChild("Child", ImVec2(0, 200), ImGuiChildFlags_Borders);
         ImGui::Checkbox("Test2", &vars.Bool2);
         ImGui::InputInt("Int1", &vars.Int1, 1, 1);
@@ -6771,6 +6776,17 @@ void RegisterTests_TestEngine(ImGuiTestEngine* e)
         ctx->SetRef("");
         ctx->ItemClick("**/Test1");
         ctx->ItemClick("**/node/Test1b");
+
+        // Test Window/Hello\/World, Test Window/node2\/sub/Test1c
+        // Labels containing a slash: "\/" inhibits the path separator.
+        ctx->SetRef("Test Window");
+        IM_CHECK_EQ(ctx->ItemInfo("**/Hello\\/World").ID, ctx->GetID("Hello\\/World"));
+        ctx->ItemClick("**/Hello\\/World");
+        ctx->ItemClick("**/node2\\/sub/Test1c");
+
+        ctx->SetRef("");
+        ctx->ItemClick("**/Hello\\/World");
+        ctx->ItemClick("**/node2\\/sub/Test1c");
 
         // Test Window/Child_XXXXX/Test2
         ctx->SetRef("");


### PR DESCRIPTION
Hi Omar, 

I stumbled upon this limitation, where a widget with a "/" in its label (e.g. `ImGui::Checkbox("Hello/World")` cannot be reached with a wildcard).  This PR is is a proposed fix.

----

* Inside ItemInfoHandleWildcardSearch():

    - We compute InSuffixLastItem and InSuffixDepth in a single loop, and do not consider "/" as a separator if escaped by "\\"
    - When computing the label hash we remove escaped slashes: Hash("Some\\/Label") = Hash("Some/Label")

* TestSuite: extended "testengine_ref_wildcard" with slashed labels

        ImGui::Checkbox("Hello/World", &vars.BoolArray[0]); // Label containing a slash
        ImGui::PushID("node2/sub");                         // Pushed ID string containing a slash
        ImGui::Checkbox("Test1c", &vars.BoolArray[1]);
        ImGui::PopID();